### PR TITLE
**OK** [FIX #63] Rollershutter items do not track changes in movement from e…

### DIFF
--- a/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/OpenWebNetBindingConstants.java
+++ b/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/OpenWebNetBindingConstants.java
@@ -149,7 +149,8 @@ public class OpenWebNetBindingConstants {
     public static final String CHANNEL_SWITCH_02 = "switch_02";
     public static final String CHANNEL_BRIGHTNESS = "brightness";
     // automation
-    public static final String CHANNEL_SHUTTER = "shutter";
+    public static final String CHANNEL_SHUTTERPOSITION = "shutterPosition";
+    public static final String CHANNEL_SHUTTERMOTION = "shutterMotion";
     // thermo
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_TEMP_TARGET = "targetTemperature";

--- a/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetAutomationHandler.java
+++ b/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetAutomationHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
@@ -131,7 +132,8 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
                     "@text/offline.wrong-configuration");
             shutterRun = SHUTTER_RUN_UNDEFINED;
         }
-        updateState(CHANNEL_SHUTTER, UnDefType.UNDEF);
+        updateState(CHANNEL_SHUTTERPOSITION, UnDefType.UNDEF);
+        updateState(CHANNEL_SHUTTERMOTION, UnDefType.UNDEF);
         positionEst = POSITION_UNKNOWN;
     }
 
@@ -146,7 +148,7 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
     @Override
     protected void handleChannelCommand(ChannelUID channel, Command command) {
         switch (channel.getId()) {
-            case CHANNEL_SHUTTER:
+            case CHANNEL_SHUTTERPOSITION:
                 handleShutterCommand(command);
                 break;
             default: {
@@ -283,6 +285,7 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
             logger.debug("==OWN:AutomationHandler== msg is command translation, ignoring...");
             return;
         }
+        updateState(CHANNEL_SHUTTERMOTION, new DecimalType(msg.getWhat().value()));
         if (msg.isUp()) {
             updateStateInt(STATE_MOVING_UP);
             if (calibrating == CALIBRATION_ACTIVATED) {
@@ -389,10 +392,10 @@ public class OpenWebNetAutomationHandler extends OpenWebNetThingHandler {
         }
         if (newPos != POSITION_UNKNOWN) {
             if (newPos != positionEst) {
-                updateState(CHANNEL_SHUTTER, new PercentType(newPos));
+                updateState(CHANNEL_SHUTTERPOSITION, new PercentType(newPos));
             }
         } else {
-            updateState(CHANNEL_SHUTTER, UnDefType.UNDEF);
+            updateState(CHANNEL_SHUTTERPOSITION, UnDefType.UNDEF);
         }
         positionEst = newPos;
     }

--- a/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/thing/BusAutomation.xml
+++ b/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/thing/BusAutomation.xml
@@ -14,7 +14,8 @@
 		<description>A OpenWebNet BUS/SCS automation device to control roller shutters, blinds, etc. BTicino models: xxx/yyyy/etc.</description>
 		
 		<channels>
-			<channel id="shutter" typeId="shutter" />
+			<channel id="shutterPosition" typeId="shutterPosition" />
+            <channel id="shutterMotion" typeId="shutterMotion" />
 		</channels>
 		
 		<properties>

--- a/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/thing/ZBAutomation.xml
+++ b/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/thing/ZBAutomation.xml
@@ -14,7 +14,8 @@
 		<description>A OpenWebNet ZigBee automation device to control roller shutters, blinds, etc. BTicino models: xxx/yyyy/etc.</description>
 		
 		<channels>
-			<channel id="shutter" typeId="shutter" />
+			<channel id="shutterPosition" typeId="shutterPosition" />
+            <channel id="shutterMotion" typeId="shutterMotion" />
 		</channels>
 		
 		<properties>

--- a/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/thing/channels.xml
+++ b/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/thing/channels.xml
@@ -39,7 +39,7 @@
 	-->
 
 	<!-- Shutter Channel -->
-	<channel-type id="shutter">
+	<channel-type id="shutterPosition">
 		<item-type>Rollershutter</item-type>
 		<label>Roller shutter</label>
 		<description>Control the roller shutter position</description>
@@ -48,6 +48,12 @@
 			<tag>Blinds</tag>
 		</tags>
 	</channel-type>
+	<channel-type id="shutterMotion">
+        <item-type>Number</item-type>
+        <label>Motion Roller shutter</label>
+        <description>Motion the roller shutter UP-DOWN-STOP</description>
+        <state readOnly="true" />
+    </channel-type>
 	
 	<!--  Thermo channels -->
 	<channel-type id="temperature">


### PR DESCRIPTION
…xternal commands

- [FIX #63] Rollershutter items do not track changes in movement from external commands
   - *[BREAKING CHANGE]* canale `shutter` cambiato nome in `shutterPosition`
   - Nuovo canale `shutterMotion` (`0`= stop, `1`= up, `2`= down)
   - **Da Completare** aggiornamento del file README.MD