### PR TITLE
Update normalizeWhere

### DIFF
--- a/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetBridgeHandler.java
+++ b/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/handler/OpenWebNetBridgeHandler.java
@@ -574,8 +574,8 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
      * @param who   the WHO
      * @return the ownId
      */
-    public String ownIdFromWhoWhere(String where, String who) {
-        return who + "." + normalizeWhere(where);
+    public String ownIdFromWhoWhere(String where, Who deviceWho) {
+        return deviceWho.value().toString() + "." + normalizeWhere(where, deviceWho);
     }
 
     /**
@@ -585,7 +585,7 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
      * @return the ownId String
      */
     private String ownIdFromMessage(BaseOpenMessage baseMsg) {
-        return baseMsg.getWho().value() + "." + normalizeWhere(baseMsg.getWhere());
+        return baseMsg.getWho().value() + "." + normalizeWhere(baseMsg.getWhere(), baseMsg.getWho());
     }
 
     /**
@@ -595,8 +595,8 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
      * @param where the WHERE address
      * @return the thing Id
      */
-    public String thingIdFromWhere(String where) {
-        return normalizeWhere(where).replace('#', 'h'); // '#' cannot be used in ThingUID;
+    public String thingIdFromWhere(String where, Who deviceWho) {
+        return normalizeWhere(where, deviceWho).replace('#', 'h'); // '#' cannot be used in ThingUID;
     }
 
     /**
@@ -605,16 +605,18 @@ public class OpenWebNetBridgeHandler extends ConfigStatusBridgeHandler implement
      * @param where the WHERE address
      * @return the normalized WHERE
      */
-    public String normalizeWhere(String where) {
+    public String normalizeWhere(String where, Who deviceWho) {
         String str = "";
         if (isBusGateway) {
             if (where.indexOf('#') < 0) { // no hash present
                 str = where;
             } else if (where.indexOf("#4#") > 0) { // local bus: APL#4#bus
                 str = where;
-            } else if (where.indexOf('#') == 0) { // thermo zone via central unit: #0 or #Z (Z=[1-99]) --> Z
+            } else if (where.indexOf('#') == 0 && deviceWho == Who.THERMOREGULATION) { // thermo zone via central unit:
+                                                                                       // #0 or #Z (Z=[1-99]) --> Z
                 str = where.substring(1);
-            } else if (where.indexOf('#') > 0) { // thermo zone and actuator N: Z#N (Z=[1-99], N=[1-9]) -- > Z
+            } else if (where.indexOf('#') > 0 && deviceWho == Who.THERMOREGULATION) { // thermo zone and actuator N: Z#N
+                                                                                      // (Z=[1-99], N=[1-9]) -- > Z
                 str = where.substring(0, where.indexOf('#'));
             } else {
                 logger.warn("==OWN== normalizeWhere() unexpected WHERE: {}", where);

--- a/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -203,7 +203,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService i
                             deviceType, where);
             }
         }
-        String tId = bridgeHandler.thingIdFromWhere(where);
+        String tId = bridgeHandler.thingIdFromWhere(where, deviceWho);
         ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, tId);
 
         DiscoveryResult discoveryResult = null;
@@ -223,11 +223,11 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService i
                     OpenWebNetBindingConstants.THING_TYPE_ZB_ON_OFF_SWITCH_2UNITS);
         }
         Map<String, Object> properties = new HashMap<>(2);
-        properties.put(OpenWebNetBindingConstants.CONFIG_PROPERTY_WHERE, bridgeHandler.normalizeWhere(where));
+        properties.put(OpenWebNetBindingConstants.CONFIG_PROPERTY_WHERE,
+                bridgeHandler.normalizeWhere(where, deviceWho));
         // properties.put(OpenWebNetBindingConstants.PROPERTY_OWNID,
         // bridgeHandler.ownIdFromWhoWhere(bridgeHandler.normalizeWhere(where), deviceWho.value().toString()));
-        properties.put(OpenWebNetBindingConstants.PROPERTY_OWNID,
-                bridgeHandler.ownIdFromWhoWhere(where, deviceWho.value().toString()));
+        properties.put(OpenWebNetBindingConstants.PROPERTY_OWNID, bridgeHandler.ownIdFromWhoWhere(where, deviceWho));
         if ((deviceType == OpenDeviceType.MULTIFUNCTION_SCENARIO_CONTROL
                 || deviceType == OpenDeviceType.SCENARIO_CONTROL) && baseMsg != null) {
             properties.put(OpenWebNetBindingConstants.CONFIG_PROPERTY_SCENARIO_BUTTONS,


### PR DESCRIPTION
Risolve la creazione del ownId con gruppi di comando.
who=`1` e where=`#1`
Prima ownId = `1.1` dopo `1.#1`