### PR TITLE
bugfix group command

### DIFF
--- a/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
+++ b/org.openhab.binding.openwebnet/src/main/java/org/openhab/binding/openwebnet/internal/discovery/OpenWebNetDeviceDiscoveryService.java
@@ -288,7 +288,7 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService i
         if (where.indexOf("#4#") > 0) {
             wheretmp = where.substring(0, where.indexOf("#4#"));
         }
-        if (wheretmp.indexOf("#") == -1) {
+        if (wheretmp.indexOf("#") == -1 && (wheretmp.indexOf("0") != 0)) {
             A = Integer.parseInt(wheretmp);
             if ((A >= 1 && A <= 9) || A == 100) {
                 logger.debug("==OWN:DeviceDiscovery== isArea() where:{} is Area", where);
@@ -307,8 +307,12 @@ public class OpenWebNetDeviceDiscoveryService extends AbstractDiscoveryService i
     public boolean isGroup(String where) {
         String wheretmp = where;
         int A = 0;
-        if (where.indexOf("#4#") > 0) {
-            wheretmp = where.substring(0, where.indexOf("#4#"));
+        if (where.indexOf("#4#") != -1) {
+            if (where.indexOf("#4#4#") == 0) {
+                wheretmp = where.substring(0, 2);
+            } else {
+                wheretmp = where.substring(0, where.indexOf("#4#"));
+            }
         }
         if (wheretmp.indexOf('#') >= 0) {
             wheretmp = wheretmp.substring(wheretmp.indexOf('#') + 1, wheretmp.length());

--- a/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/binding/binding.xml
+++ b/org.openhab.binding.openwebnet/src/main/resources/ESH-INF/binding/binding.xml
@@ -3,7 +3,7 @@
 	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
-	<name>OpenWebNet Binding (2.5.0.M3.pre6)</name>
+	<name>OpenWebNet Binding (2.5.0.M3.pre7)</name>
 	<description>The OpenWebNet Binding integrates the BTicino/Legrand 'MyHOME' connected home system using the OpenWebNet protocol. It supports BUS (SCS) and ZigBee USB gateways to control BTicino/Legrand switches, dimmers, shutters, thermostasts, CEN/CEN+ scenarios, etc.</description>
 	<author>Massimo Valla</author>
 


### PR DESCRIPTION
Different corrections to differentiate the management of the local bus
- Fix bug `normalizeWhere` for group command with different local bus
- Fix bug `isArea` for group command with different local bus
- Fix bug `isGroup` for group command with different local bus
- Fix bug `isGeneral` for group command with different local bus
- Fix bug `isCompareALocalBus` for group command with different local bus
- Fix bug `isCompareLocalBus` for group command with different local bus